### PR TITLE
Fix/crash on success (Android)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Fixed issue where SDK could crash unexpectedly after passing verification successfully.
+
 ## 0.1.1
 
 * Fixed issue where iOS `Podfile` could not find the required files to download the SDK.

--- a/android/src/main/kotlin/com/klippa/identity_verification/klippa_identity_verification_sdk/KlippaIdentityVerificationSdkPlugin.kt
+++ b/android/src/main/kotlin/com/klippa/identity_verification/klippa_identity_verification_sdk/KlippaIdentityVerificationSdkPlugin.kt
@@ -33,7 +33,8 @@ class KlippaIdentityVerificationSdkPlugin: FlutterPlugin, MethodCallHandler, Act
 
   private val listener = object: IdentityBuilderListener {
     override fun identityVerificationFinished() {
-      resultHandler?.success(null)
+      val resultMap = HashMap<String, Any>()
+      resultHandler?.success(resultMap)
     }
 
     override fun identityVerificationCanceled(error: KlippaError) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: klippa_identity_verification_sdk
 description: Allows you to do identity verification with the Klippa Identity Verification SDK from Flutter apps.
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/klippa-app/flutter-klippa-identity-verification-sdk
 
 environment:


### PR DESCRIPTION
Fixed an issue where the SDK could crash when successfully passing the verification. (Android only)